### PR TITLE
Remove fill from Truck icon so that all will be outlined

### DIFF
--- a/src/assets/styles/partials/contact-bar.scss
+++ b/src/assets/styles/partials/contact-bar.scss
@@ -48,8 +48,6 @@ $green: #89f302;
   }
 
   .truck {
-    fill: #0c0c0c;
-
     :hover {
       cursor: default;
     }


### PR DESCRIPTION
@HarshaAbeyvickrama  Please review if the icon is okay - removed the filling from the icon so it will now look as the rest. (outlined) 